### PR TITLE
Feat 경로탐색시 출발지 도착지 추가

### DIFF
--- a/src/apis/hooks/useGetRoutes.ts
+++ b/src/apis/hooks/useGetRoutes.ts
@@ -5,21 +5,30 @@ import { Route } from '@/types'
 interface Request {
   start: string
   goal: string
+  startName?: string
+  goalName?: string
   waypoints?: string[]
   page: string
 }
 
-const useGetRoutes = ({ start, goal, waypoints, page }: Request) => {
+const useGetRoutes = ({
+  start,
+  goal,
+  startName,
+  goalName,
+  waypoints,
+  page,
+}: Request) => {
   const getRoutes = async () => {
     const response = await apiClient.get(
-      `/route?start=${start}&goal=${goal}&page=${page}
+      `/route?start=${start}&goal=${goal}&startName=${startName}&goalName=${goalName}&page=${page}
       ${waypoints ? `&waypoints=${waypoints.join('%7c')}` : ''}`,
     )
 
     return response.data.data
   }
 
-  const queryKey = ['routes', start, goal, waypoints, page]
+  const queryKey = ['routes', start, goal, startName, goalName, waypoints, page]
 
   return useQuery<Route[], Error>({
     queryKey,

--- a/src/pages/NaverPage/components/Main/index.tsx
+++ b/src/pages/NaverPage/components/Main/index.tsx
@@ -35,6 +35,8 @@ const Main = () => {
     useGetRoutes({
       start: [startPlace?.lng, startPlace?.lat].join(','),
       goal: [goalPlace?.lng, goalPlace?.lat].join(','),
+      startName: startPlace?.name,
+      goalName: goalPlace?.name,
       // waypoints: waypoints.map(waypoint =>
       //   [waypoint.lng, waypoint.lat].join(','),
       // ),

--- a/src/pages/NaverPage/components/PathInfo/index.tsx
+++ b/src/pages/NaverPage/components/PathInfo/index.tsx
@@ -1,6 +1,6 @@
 import PathInfoContent from './pathInfoContent'
 import { Dispatch, SetStateAction } from 'react'
-import { useGetRoutes } from '@/apis/hooks'
+// import { useGetRoutes } from '@/apis/hooks'
 import { Route, Place } from '@/types'
 import { Loading } from '../'
 import './index.css'
@@ -22,30 +22,30 @@ interface PathInfoProps {
 
 const PathInfo = ({
   routeList,
-  setRouteList,
+  // setRouteList,
   setSelectedRoute,
   clickedRouteIndex,
   setClickedRouteIndex,
   startPlace,
   goalPlace,
   clickedMorePath,
-  setClickedMorePath,
+  // setClickedMorePath,
   setRestSpotModalOpen,
   setClickedRestSpot,
 }: PathInfoProps) => {
-  const { refetch: routesRefetch, isLoading: isGetRoutesLoading } =
-    useGetRoutes({
-      start: [startPlace?.lng, startPlace?.lat].join(','),
-      goal: [goalPlace?.lng, goalPlace?.lat].join(','),
-      page: '2',
-    })
+  // const { refetch: routesRefetch, isLoading: isGetRoutesLoading } =
+  //   useGetRoutes({
+  //     start: [startPlace?.lng, startPlace?.lat].join(','),
+  //     goal: [goalPlace?.lng, goalPlace?.lat].join(','),
+  //     page: '2',
+  //   })
 
-  const handleClickMorePathData = () => {
-    routesRefetch().then(
-      routes => routes.data && setRouteList([...routeList, ...routes.data]),
-    )
-    setClickedMorePath(true)
-  }
+  // const handleClickMorePathData = () => {
+  //   routesRefetch().then(
+  //     routes => routes.data && setRouteList([...routeList, ...routes.data]),
+  //   )
+  //   setClickedMorePath(true)
+  // }
 
   const handleClick = (route: Route, index: number) => {
     setClickedRouteIndex(index)
@@ -74,7 +74,7 @@ const PathInfo = ({
           )
         })}
 
-        {isGetRoutesLoading && clickedMorePath ? (
+        {clickedMorePath ? (
           <Loading className="bottom" />
         ) : (
           // <div

--- a/src/pages/NaverPage/components/PathInfo/index.tsx
+++ b/src/pages/NaverPage/components/PathInfo/index.tsx
@@ -77,12 +77,13 @@ const PathInfo = ({
         {isGetRoutesLoading && clickedMorePath ? (
           <Loading className="bottom" />
         ) : (
-          <div
-            className={`moreBtn  ${clickedMorePath && 'hidden'}`}
-            onClick={handleClickMorePathData}
-          >
-            더보기
-          </div>
+          // <div
+          //   className={`moreBtn  ${clickedMorePath && 'hidden'}`}
+          //   onClick={handleClickMorePathData}
+          // >
+          //   더보기
+          // </div>
+          <></>
         )}
       </div>
       <p className="searchInfo">


### PR DESCRIPTION
## 💡 개요 (필수)

- 통계 볼 때 출발지, 도착지 파악이 어려움
- 더보기 버튼으로 인해 의미없는 조회 발생

## 📃 작업내용 (필수)

- 경로 조회 API 호출 시 출발지명, 도착지명도 포함하도록 수정
- 더보기 버튼 삭제
