### PR TITLE
feat: 주소로 검색시 새로운 Api 구축 및 대응 #2 

### DIFF
--- a/src/apis/hooks/index.ts
+++ b/src/apis/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useGetRoutes } from './useGetRoutes'
 export { default as useGetRestSpots } from './useGetRestSpots'
 export { default as useGetSearchSpot } from './useGetSearchSpot'
+export { default as useGetSearchSportsByAdress } from './useGetSearchSpotsByAdress'

--- a/src/apis/hooks/useGetSearchSpotsByAdress.ts
+++ b/src/apis/hooks/useGetSearchSpotsByAdress.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query'
+import apiClient from '../apiClient'
+import { Place } from '@/types'
+
+interface Request {
+  addressSearchTerm: string | undefined
+}
+
+const useGetSearchSportsByAdress = ({ addressSearchTerm }: Request) => {
+  const getSearch = async () => {
+    const response = await apiClient.get(
+      //todo 임시 api 작성
+      `/place/naver?searchTermByAdress=${addressSearchTerm}`,
+    )
+    return response.data.data
+  }
+
+  return useQuery<Place[], Error>({
+    queryKey: ['search'],
+    queryFn: getSearch,
+    enabled: !!addressSearchTerm,
+  })
+}
+
+export default useGetSearchSportsByAdress

--- a/src/pages/NaverPage/components/InputSubmit/inputText.tsx
+++ b/src/pages/NaverPage/components/InputSubmit/inputText.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react'
 import { useDebounce } from '@/hooks'
 import { Place } from '@/types'
-import { useGetSearchSpot } from '@/apis/hooks'
+import { useGetSearchSpot, useGetSearchSportsByAdress } from '@/apis/hooks'
 import './inputText.css'
 
 interface InputProps {
@@ -19,6 +19,11 @@ interface InputProps {
   setShowRouteList: Dispatch<SetStateAction<boolean>>
   setRestSpotModalOpen: Dispatch<SetStateAction<boolean>>
   addPlaceHistory: (place: Place) => void
+}
+
+const isAddress = (input: string): boolean => {
+  const roadAddressPattern = /[가-힣]{2,}(로|길|읍|면|동|리|가|구|시)/
+  return roadAddressPattern.test(input)
 }
 
 const InputType = {
@@ -41,12 +46,19 @@ const InputText = ({
   setRestSpotModalOpen,
   addPlaceHistory,
 }: InputProps) => {
-  const [placeholder, setPlaceholder] = useState<string>(InputType.PLACEHOLDER[type])
+  const [placeholder, setPlaceholder] = useState<string>(
+    InputType.PLACEHOLDER[type],
+  )
   const [searchKeyword, setSearchKeyword] = useState<string>('')
   const [placeList, setPlaceList] = useState<Place[] | undefined>([])
   const [modalIsOpen, setModalIsOpen] = useState(false)
   const debouncedPlace = useDebounce(searchKeyword || '')
-  const { refetch } = useGetSearchSpot({ searchTerm: debouncedPlace })
+  const { refetch: refetchByKeyword } = useGetSearchSpot({
+    searchTerm: debouncedPlace,
+  })
+  const { refetch: refetchByAddress } = useGetSearchSportsByAdress({
+    addressSearchTerm: debouncedPlace,
+  })
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const inputValue = e.target.value
@@ -83,10 +95,17 @@ const InputText = ({
   }
 
   useEffect(() => {
-    !isSingleConsonant(debouncedPlace) && debouncedPlace
-      ? refetch().then(res => setPlaceList(res.data))
-      : setPlaceList([])
-  }, [debouncedPlace, refetch])
+    if (isSingleConsonant(debouncedPlace) || debouncedPlace === '') {
+      setPlaceList([])
+      return
+    }
+
+    if (isAddress(debouncedPlace)) {
+      refetchByAddress().then(res => setPlaceList(res.data))
+    } else {
+      refetchByKeyword().then(res => setPlaceList(res.data))
+    }
+  }, [debouncedPlace, refetchByAddress, refetchByKeyword])
 
   useEffect(() => {
     if (isReset) {


### PR DESCRIPTION
# 설명
- 새로운 api를 만들어 사용자가 주소로 입력했을시 주소지를 반환할수 있는 api로 데이터를 요청할수 있게 대응하였습니다.

# 고려할점
- 로직은 정규 표현식을 사용했으며 주소값의 예시는 아래 사진과 같습니다.
<img width="230" alt="스크린샷 2025-05-26 오전 12 29 59" src="https://github.com/user-attachments/assets/2215c6a9-aedd-44dc-bdc5-6876cc46131f" />

# edge case
- 서버 측 API가 아직 정식 반영되지 않아, 테스트용으로 /place/naver?searchTermByAdress 엔드포인트를 임시 설정했습니다.

# test case
- [x] 입력된 값이 주소일 경우에는 신규 API를 통해 데이터를 요청하고, 그렇지 않으면 기존 API를 사용해 검색하는지
