### PR TITLE
fix: useGetSearchSportsByAdress

### DIFF
--- a/src/apis/hooks/useGetSearchSpotsByAddress.ts
+++ b/src/apis/hooks/useGetSearchSpotsByAddress.ts
@@ -10,13 +10,13 @@ const useGetSearchSportsByAdress = ({ addressSearchTerm }: Request) => {
   const getSearch = async () => {
     const response = await apiClient.get(
       //todo 임시 api 작성
-      `/place/naver?searchTermByAddress=${addressSearchTerm}`,
+      `/place/naver/address?address=${addressSearchTerm}`,
     )
     return response.data.data
   }
 
   return useQuery<Place[], Error>({
-    queryKey: ['search'],
+    queryKey: ['searchAddress'],
     queryFn: getSearch,
     enabled: !!addressSearchTerm,
   })


### PR DESCRIPTION
## 💡 개요
- 복사 붙여넣기로 주소 입력 시 검색 결과가 표시되지 않는 문제 해결

## 🐛 문제점
- 주소 복사 붙여넣기 후 검색 결과 미표시
- React Query 캐싱 충돌로 인한 잘못된 API 호출

## 📋 변경사항
### React Query 캐싱 충돌 해결
- **문제**: 동일한 queryKey로 인한 캐시 공유
- **해결**: queryKey 분리 (`['search']` → `['searchAddress']`)